### PR TITLE
docs: fix grammar errors and clarify edit command constraints

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -110,7 +110,7 @@ How the `Logic` component works:
 
 1. When `Logic` is called upon to execute a command, it is passed to an `AddressBookParser` object which in turn creates a parser that matches the command (e.g., `DeleteCommandParser`) and uses it to parse the command.
 1. This results in a `Command` object (more precisely, an object of one of its subclasses e.g., `DeleteCommand`) which is executed by the `LogicManager`.
-1. The command can communicate with the `Model` when it is executed (e.g. to delete an application).<br>
+1. The command can communicate with the `Model` when it is executed (e.g., to delete an application).<br>
    Note that although this is shown as a single step in the diagram above (for simplicity), in the code it can take several interactions (between the command object and the `Model`) to achieve.
 1. The result of the command execution is encapsulated as a `CommandResult` object which is returned back from `Logic`.
 
@@ -120,7 +120,7 @@ Here are the other classes in `Logic` (omitted from the class diagram above) tha
 
 How the parsing works:
 * When called upon to parse a user command, the `AddressBookParser` class creates an `XYZCommandParser` (`XYZ` is a placeholder for the specific command name e.g., `AddCommandParser`) which uses the other classes shown above to parse the user command and create a `XYZCommand` object (e.g., `AddCommand`) which the `AddressBookParser` returns back as a `Command` object.
-* All `XYZCommandParser` classes (e.g., `AddCommandParser`, `DeleteCommandParser`, ...) inherit from the `Parser` interface so that they can be treated similarly where possible e.g, during testing.
+* All `XYZCommandParser` classes (e.g., `AddCommandParser`, `DeleteCommandParser`, ...) inherit from the `Parser` interface so that they can be treated similarly where possible (e.g., during testing).
 
 ### Model component
 **API** : [`Model.java`](https://github.com/AY2526S2-CS2103T-W12-2/tp/blob/master/src/main/java/seedu/address/model/Model.java)
@@ -335,7 +335,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 | `* * *`  | user            | update an application status                      | track the progress of my application                    |
 | `* * *`  | user            | save the application date for each application    | track my applications efficiently                       |
 | `* * *`  | user            | save data on my hard disk                         | access my records locally                               |
-| `* * *`  | user            | add a application URL to an entry                 | have a reference to the original application page       |
+| `* * *`  | user            | add an application URL to an entry                 | have a reference to the original application page       |
 | `* * `   | user            | copy an application URL                           | quickly open the link in my browser without retyping it |
 | `* * `   | user            | add notes to an application                       | store reminders or interview details                    |
 | `* *`    | user            | filter the list by status                         | see only my active applications                         |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -280,12 +280,13 @@ Edits an existing application in LockedIn.
 * `INDEX` must be a positive integer.
 * You must provide at least one field to edit.
 * Existing values are updated to the input values.
-* `COMPANY` and `ROLE` must not be blank.
-* `COMPANY` and `ROLE` may contain only [supported characters](#supported-characters).
-* `COMPANY` must be at most 100 characters long.
-* `ROLE` must be at most 100 characters long.
-* `APPLICATION_DATE` must be a valid date in the format `yyyy-MM-dd`.
+* `COMPANY` and `ROLE`, if provided, cannot be blank.
+* `COMPANY` and `ROLE`, if provided, may contain only [supported characters](#supported-characters).
+* `COMPANY`, if provided, must be at most 100 characters long.
+* `ROLE`, if provided, must be at most 100 characters long.
+* `APPLICATION_DATE`, if provided, must be a valid date in the format `yyyy-MM-dd`.
 * `URL`, if provided, must start with `http://` or `https://`.
+* `STATUS`, if provided, must be one of: `Applied`, `OA`, `Interview`, `Offered`, `Rejected`, `Withdrawn`.
 * If the edited values make the application a duplicate of an existing one, the edit is rejected.
 
 **Examples**
@@ -354,7 +355,7 @@ For date fields, it can either find exact dates or find dates within a range (in
 **Notes**
 
 * You must provide at least one field.
-* You cannot provide an empty parameter. A prefix must be followed by at least one keyword (e.g. `find n/` is invalid).
+* You cannot provide an empty parameter. A prefix must be followed by at least one keyword (e.g., `find n/` is invalid).
 * The search is case-insensitive.
   Example: `n/google` matches `Google`.
 * For company, role, URL, and status, applications matching at least one keyword in the same field are returned.
@@ -780,7 +781,7 @@ A: No. LockedIn currently supports only English letters, digits, spaces, and a [
 
 <br>
 
-**Q: Why does certain fonts not work properly?**<br>
+**Q: Why do certain fonts not work properly?**<br>
 A: LockedIn validates the company, role, and note fields using an ASCII-only character set, so other fonts not in the set may be rejected.
 
 <br>

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -20,7 +20,7 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a application to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an application to the address book. "
             + "Parameters: "
             + PREFIX_COMPANY + "COMPANY "
             + PREFIX_ROLE + "ROLE "


### PR DESCRIPTION
- Fix articles: "a application" → "an application"
- Fix subject-verb agreement: "does" → "do" for "certain fonts"
- Standardize "e.g." abbreviation formatting with commas
- Clarify that all edit command optional fields have validation constraints
- Add STATUS field constraints to edit command documentation

Fixes #211 
Fixes #210 
Fixes #206 