### PR TITLE
Fix alias validation bug, shorten feedback messages, and update DG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -162,12 +162,17 @@ This section describes some noteworthy details on how certain features are imple
 
 Alias support is implemented through a collaboration between `AddressBookParser`, `Model`, and `UserPrefs`:
 
-1. `AddressBookParser#parseCommand` extracts the command word and checks whether it exists in the alias map.
-1. If a mapping exists, the alias is rewritten to the corresponding built-in command word before dispatch.
-1. `AliasCommand` validates that the target command is supported and the alias itself is not a built-in command.
-1. Valid mappings are persisted via `Model#setAlias(...)`, which writes to `UserPrefs`.
-1. `UnaliasCommand` removes a mapping via `Model#removeAlias(...)`.
-1. `AliasListCommand` renders all current mappings in alphabetical order.
+1. `AddressBookParser#parseCommand` first performs an initial split of the raw user input into:
+    * the first token (`commandWord`)
+    * the remaining text (`arguments`)
+2. It then checks whether `commandWord` exists in the alias map.
+3. If a mapping exists, only the extracted `commandWord` is rewritten to the corresponding built-in command word.
+4. The rewritten command word is then dispatched to the matching built-in command parser.
+5. Command-specific parsing of `arguments` (such as prefix detection and argument tokenization) happens only after this dispatch, inside the selected parser.
+6. `AliasCommand` validates that the target command is supported and the alias itself is not a built-in command.
+7. Valid mappings are persisted via `Model#setAlias(...)`, which writes to `UserPrefs`.
+8. `UnaliasCommand` removes a mapping via `Model#removeAlias(...)`.
+9. `AliasListCommand` renders all current mappings in alphabetical order.
 
 <puml src="diagrams/AliasSequenceDiagram.puml" alt="Interactions inside Logic and Model for alias creation" />
 
@@ -324,40 +329,49 @@ in a CLI environment. It allows target users to log application updates, record 
 
 ### User stories
 
-Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unlikely to have) - `*`
+Priorities:
+High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unlikely to have) - `*`
 
-| Priority | As a …​         | I want to …​                                      | So that I can…​                                         |
-|----------|-----------------|---------------------------------------------------|---------------------------------------------------------|
-| `* * *`  | first time user | add an application record                         | track my application                                    |
-| `* * *`  | first time user | view all applications in a list                   | see all my applications                                 |
-| `* * *`  | first time user | delete application records                        | remove companies I am no longer interested in           |
-| `* * *`  | first time user | edit an application's details                     | correct mistakes I made                                 |
-| `* * *`  | user            | update an application status                      | track the progress of my application                    |
-| `* * *`  | user            | save the application date for each application    | track my applications efficiently                       |
-| `* * *`  | user            | save data on my hard disk                         | access my records locally                               |
-| `* * *`  | user            | add a application URL to an entry                 | have a reference to the original application page       |
-| `* * `   | user            | copy an application URL                           | quickly open the link in my browser without retyping it |
-| `* * `   | user            | add notes to an application                       | store reminders or interview details                    |
-| `* *`    | user            | filter the list by status                         | see only my active applications                         |
-| `* *`    | user            | filter applications by company name and role      | find relevant applications quickly                      |
-| `* *`    | user            | filter applications by application date           | find applications submitted during a specific period quickly                      |
-| `* *`    | user            | filter applications by URL                        | find applications linked to a specific job posting quickly |
-| `* *`    | user             | remove rejected or withdrawn applications quickly | keep my application list clean         |
-| `* *`    | user            | view total number of applications by status       | track my overall progress                               |
-| `* *`    | expert user     | use short aliases                                 | type commands faster                                    |
-| `* *`    | expert user      | remove aliases                              | stop using shortcuts I no longer need               | Add |
-| `* *`    | expert user      | view all saved aliases                      | remember what shortcuts I created                   |
-| `* *`    | expert user     | cycle through previous commands                   | reuse previously typed commands                         |
-| `* *`    | user            | view the potential pay of each position           | know which applications result in higher pay            |
-| `* *`    | user            | filter the list by pay range                      | determine expected salary levels                        |
-| `*`      | user            | favourite companies                               | track companies I am particularly interested in         |
-| `*`      | first time user | see dummy data                                    | understand how the data is structured                   |
-| `*`      | expert user     | use tab completion                                | avoid typing full commands                              |
-| `*`      | user            | pin the application window on top                 | keep the logbook visible while browsing job portals     |
-| `*`      | user            | undo a command                                    | recover from accidental deletions                       |
-| `*`      | expert user     | export data into another file format              | keep backups or reuse data elsewhere                    |
-| `*`      | expert user     | add tags to companies                             | record additional information about companies           |
+Status:
+* `✓` — implemented in the current version
+* `○` — planned for a future version
 
+| Priority | As a …​         | I want to …​                                                | So that I can…​                                               | Status |
+|----------|-----------------|-------------------------------------------------------------|---------------------------------------------------------------|--------|
+| `* * *`  | first-time user | add an application record                                   | track my internship applications                              | `✓` |
+| `* * *`  | first-time user | view all applications in a list                             | see all my applications at a glance                           | `✓` |
+| `* * *`  | user            | edit an application's details                               | correct mistakes I made                                       | `✓` |
+| `* * *`  | user            | delete an application record                                | remove applications I no longer want to track                 | `✓` |
+| `* * *`  | user            | update an application's status                              | track the progress of each application                        | `✓` |
+| `* * *`  | user            | save data automatically on my hard disk                     | keep my records without manually saving                       | `✓` |
+| `* * *`  | user            | record the application date for each application            | track when I applied                                          | `✓` |
+| `* * *`  | user            | attach a URL to an application                              | keep a reference to the original job posting                  | `✓` |
+| `* *`    | user            | copy an application's URL                                   | open the link quickly without retyping                        | `✓` |
+| `* *`    | user            | add notes to an application                                 | store reminders or interview details                          | `✓` |
+| `* *`    | user            | clear a note from an application                            | remove outdated notes                                         | `✓` |
+| `* *`    | user            | filter applications by company name                         | find relevant applications quickly                            | `✓` |
+| `* *`    | user            | filter applications by role                                 | find relevant applications quickly                            | `✓` |
+| `* *`    | user            | filter applications by application date or date range       | find applications submitted during a certain period           | `✓` |
+| `* *`    | user            | filter applications by URL                                  | find applications linked to a specific posting                | `✓` |
+| `* *`    | user            | filter applications by status                               | focus on applications at a specific stage                     | `✓` |
+| `* *`    | user            | restore the full application list after filtering           | return to viewing everything easily                           | `✓` |
+| `* *`    | user            | clear all applications in the current displayed list        | remove a group of shown applications quickly                  | `✓` |
+| `* *`    | user            | remove terminal applications from the current displayed list| keep my list clean by removing rejected or withdrawn entries  | `✓` |
+| `* *`    | expert user     | use short aliases for commands                              | type commands faster                                          | `✓` |
+| `* *`    | expert user     | remove aliases                                              | stop using shortcuts I no longer need                         | `✓` |
+| `* *`    | expert user     | view all saved aliases                                      | remember what shortcuts I created                             | `✓` |
+| `* *`    | expert user     | keep my aliases across restarts                             | avoid recreating them every time I open the app               | `✓` |
+| `* *`    | expert user     | cycle through previously entered commands                   | reuse or edit past commands quickly                           | `✓` |
+| `* *`    | user            | view the total number of applications by status             | track my overall progress                                     | `○` |
+| `* *`    | user            | view the potential pay of each position                     | compare opportunities more easily                             | `○` |
+| `* *`    | user            | filter applications by pay range                            | focus on opportunities within a salary range                  | `○` |
+| `*`      | user            | favourite companies                                         | keep track of companies I care about most                     | `○` |
+| `*`      | first-time user | see sample data on first launch                             | understand how the data is structured                         | `✓` |
+| `*`      | expert user     | use tab completion                                          | avoid typing full commands                                    | `○` |
+| `*`      | user            | pin the application window on top                           | keep it visible while browsing job portals                    | `○` |
+| `*`      | user            | undo a command                                              | recover from accidental changes                               | `○` |
+| `*`      | expert user     | export data into another file format                        | keep backups or reuse data elsewhere                          | `○` |
+| `*`      | expert user     | add tags to applications or companies                       | organize records with more flexibility                        | `○` |
 
 ### Use cases
 

--- a/src/main/java/seedu/address/logic/commands/AliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AliasCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Locale;
 import java.util.Set;
 
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -68,7 +69,7 @@ public class AliasCommand extends Command {
             throw new CommandException(MESSAGE_INVALID_TARGET);
         }
 
-        if (isSupportedCommandWord(alias)) {
+        if (isReservedAlias(alias)) {
             throw new CommandException(MESSAGE_INVALID_ALIAS);
         }
 
@@ -95,12 +96,18 @@ public class AliasCommand extends Command {
 
     /**
      * Returns true if the given word is a valid built-in command word supported by the application.
-     *
      * @param word The word to check.
      * @return True if the word is a supported command word, false otherwise.
      */
     private boolean isSupportedCommandWord(String word) {
         return SUPPORTED_COMMAND_WORDS.contains(word);
+    }
+
+    /**
+     * Returns true if the alias clashes with any built-in command word, ignoring case.
+     */
+    private boolean isReservedAlias(String word) {
+        return SUPPORTED_COMMAND_WORDS.contains(word.toLowerCase(Locale.ROOT));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -33,7 +33,7 @@ public class EditCommand extends Command {
     public static final String COMMAND_WORD = "edit";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the application identified "
-            + "by the index number used in the displayed application list. "
+            + "by the index number used in the displayed application list.\n"
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_COMPANY + "COMPANY] "

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -16,8 +16,8 @@ public class FindCommand extends Command {
     public static final String COMMAND_WORD = "find";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all applications whose company names, roles, "
-            + "application dates, urls or statuses contain any of the specified keywords (case-insensitive) and "
-            + "displays them as a list with index numbers.\n"
+            + "application dates, urls or statuses contain any of the specified keywords (case-insensitive).\n"
+            + "Matching applications are displayed as a list with index numbers.\n"
             + "Parameters: [n/COMPANY_NAME] [r/ROLE] [d/APPLICATION_DATE] or [d/START_DATE:END_DATE] [u/URL] "
             + "[s/STATUS]...\n"
             + "Example: " + COMMAND_WORD + " n/Google r/Intern d/2022-12-12:2022-12-15 "

--- a/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AliasCommandTest.java
@@ -44,6 +44,15 @@ public class AliasCommandTest {
     }
 
     @Test
+    public void execute_aliasIsCaseVariantOfExistingCommandWord_throwsCommandException() {
+        Model model = new ModelManager();
+
+        AliasCommand aliasCommand = new AliasCommand("ADD", "delete");
+
+        assertCommandFailure(aliasCommand, model, AliasCommand.MESSAGE_INVALID_ALIAS);
+    }
+
+    @Test
     public void execute_existingAlias_overwritesAlias() throws Exception {
         Model model = new ModelManager();
         model.setAlias("ls", "list");


### PR DESCRIPTION
## Summary
Fixes the alias reserved-command bug, improves command feedback readability, and updates the Developer Guide to better reflect the current implementation.

## Changes made
- fixed the alias validation bug so case variants of built-in command words can no longer be used as aliases
  - example: `alias ADD delete` is now rejected
- added a regression test for the alias bug
- modified the `edit` and `find` result messages so they do not require horizontal scrolling as much
- updated the DG user stories table
  - added a status column
  - refined several stories and implementation markers
- clarified the alias implementation order in the DG
  - alias expansion now documents the actual parsing flow more precisely

Fixes #198 
FIxes #204 
Fixes #208 
Fixes #223 